### PR TITLE
Add Screen Wake Lock annoyance

### DIFF
--- a/static/index.js
+++ b/static/index.js
@@ -215,6 +215,10 @@ function init () {
     speak()
     startTheramin()
 
+        if (navigator.wakeLock) {
+               navigator.wakeLock.request('screen').catch(() => {})
+        }
+
     // Capture key presses on the Command or Control keys, to interfere with the
     // "Close Window" shortcut.
     if (event.key === 'Meta' || event.key === 'Control') {


### PR DESCRIPTION
Adds a tiny new annoyance using the Screen Wake Lock API from the existing user-interaction handler. On supporting browsers, each interaction tries to keep the display awake.

The request is feature-detected and rejected permissions are ignored, matching the existing browser API annoyance style.